### PR TITLE
Serializer profiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,10 @@ matrix:
       env: TOX_ENV=py36
     - python: 3.7
       dist: xenial
-      env: TOX_ENV="py37,lint"
+      env: TOX_ENV=py37
+    - python: 3.8
+      dist: xenial
+      env: TOX_ENV="py38,lint"
 
 before_install:
   - pip install --upgrade pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,14 @@
+0.2.0
+~~~~~
+
+* Improve BaseOutput to handle file location bevavior
+* Add utils get_value_from_config function to retrieve drf viewset configs
+* Add readme to pyprojec.toml to generate the long description in setup.py
+* Add configuration `ENABLE_SERIALIZER_PROFILER`. In cases when this config is True and the viewset
+has the `get_serializer_class` method, the decorator line_profiler_viewset will automatically profile
+the methods and functions from the serializer vinculated with the viewset
+* Add support to python 3.8
+
 0.1.0
 ~~~~~
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,14 @@
 
 # drf-viewset-profiler
 
-Decorator to profile all methods from a viewset line by line. For all methods that were called during a request, an output
+Decorator to profile all methods from a viewset (and its serializer) line by line. For all methods that were called during a request, an output
 will be generated showing the number of hits, time (in seconds), lines and the content of each line of a method that was executed
 
 ## Installation
-Due to a problem with `line_profiler` installation, it's necessary to follow these instructions [1] to install, or just do `pip install Cython` and force to install this lib again
+
+`pip install drf-viewset-profiler`
+
+Note: due to a problem with `line_profiler` installation, it's necessary to follow these instructions [1] to install, or just do `pip install Cython` and force to install this lib again
 
 1 - https://github.com/rkern/line_profiler#installation
 
@@ -40,19 +43,21 @@ Make requests in this viewset to profile and measure the time in seconds wasted
 DRF_VIEWSET_PROFILER = {
     "DEFAULT_OUTPUT_GENERATION_TYPE": "drf_viewset_profiler.output.FileOutput",
     "DEFAULT_OUTPUT_LOCATION": "",
+    "ENABLE_SERIALIZER_PROFILER": True
 }
 ```
 
-There are two options to generate the profile information:
-
-#### DRF_VIEWSET_PROFILER
+#### DEFAULT_OUTPUT_GENERATION_TYPE
 - drf_viewset_profiler.output.FileOutput: generates the output in a txt file with the name of the profiled viewset
-- drf_viewset_profiler.output.StdOutput: generates the output in the console
+- drf_viewset_profiler.output.StdOutput: generates the output in the console (default)
 
 It's possible to customize by extending the BaseOuput class
 
 #### DEFAULT_OUTPUT_LOCATION
-- the location to generate the output file with the name of the view that will profiled
+- the location to generate the output file with the name of the view that will profiled (default is empty)
+
+#### ENABLE_SERIALIZER_PROFILER
+- profile the methods from the serializer vinculated with the viewset (default is True)
 
 #### Output example
 

--- a/drf_viewset_profiler/decorators.py
+++ b/drf_viewset_profiler/decorators.py
@@ -1,4 +1,6 @@
-from .utils import create_line_profile
+from .utils import create_line_profile, get_value_from_config
+
+enable_serializer_profiler = get_value_from_config("ENABLE_SERIALIZER_PROFILER", True)
 
 
 def line_profiler_viewset(viewset):
@@ -27,8 +29,12 @@ def line_profiler_viewset(viewset):
     class LineProfilerViewSet(viewset):
         def initialize_request(self, request, *args, **kwargs):
             request = super().initialize_request(request, *args, **kwargs)
-            line_profiler = create_line_profile(viewset)
-            request.line_profiler = line_profiler
+            args = [viewset]
+
+            if enable_serializer_profiler and hasattr(viewset, "get_serializer_class"):
+                args.append(viewset.get_serializer_class(self))
+
+            request.line_profiler = create_line_profile(*args)
             return request
 
     LineProfilerViewSet.__name__ = viewset.__name__

--- a/drf_viewset_profiler/utils.py
+++ b/drf_viewset_profiler/utils.py
@@ -1,17 +1,25 @@
 import inspect
 
+from django.conf import settings
 from line_profiler import LineProfiler
 
+drf_viewset_config = getattr(settings, "DRF_VIEWSET_PROFILER", {})
 
-def create_line_profile(klass):
+
+def create_line_profile(*args):
     line_profiler = LineProfiler()
     line_profiler.enable_by_count()
 
-    for attr in dir(klass):
-        func = getattr(klass, attr)
-        condition = (not inspect.isfunction(func), not inspect.ismethod(func))
-        if all(condition):
-            continue
-        line_profiler.add_function(func)
+    for klass in args:
+        for attr in dir(klass):
+            func = getattr(klass, attr)
+            condition = (not inspect.isfunction(func), not inspect.ismethod(func))
+            if all(condition):
+                continue
+            line_profiler.add_function(func)
 
     return line_profiler
+
+
+def get_value_from_config(config, default):
+    return drf_viewset_config.get(config, default)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,9 @@
 [tool.poetry]
 name = "drf-viewset-profiler"
-version = "0.1.0"
+version = "0.2.0"
 description = "Lib to profile all methods from a viewset line by line"
 license = "MIT"
+readme = 'README.md'
 authors = [
     "Frederico V Lima <frederico.vieira@gmail.com>"
 ]
@@ -39,16 +40,16 @@ default_section = "THIRDPARTY"
 
 [tool.poetry.dependencies]
 python = "^3.6"
-Cython = "^0.29.13"
+Cython = "^0.29"
 line_profiler = { git = "https://github.com/rkern/line_profiler" }
 
 [tool.poetry.dev-dependencies]
-black = { version = "^18.3-alpha.0", allows-prereleases = true }
+black = { version = "^19", allows-prereleases = true }
 Django = "^2.0"
-djangorestframework = "^3.10.0"
-model-mommy = "^1.6.0"
-pre-commit = "^1.18.3"
-pytest = "^5.2.1"
-pytest-cov = "^2.8.1"
-pytest-django = "^3.5.1"
-python-status = "^1.0.1"
+djangorestframework = "^3.10"
+model-mommy = "^1.6"
+pre-commit = "^1.18"
+pytest = "^5.2"
+pytest-cov = "^2.8"
+pytest-django = "^3.5"
+python-status = "^1.0"

--- a/test-drf-project/test_drf_project/settings.py
+++ b/test-drf-project/test_drf_project/settings.py
@@ -48,7 +48,6 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "test_drf_project.wsgi.application"
 
-
 DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}
 
 AUTH_PASSWORD_VALIDATORS = [
@@ -81,4 +80,5 @@ REST_FRAMEWORK = {
 DRF_VIEWSET_PROFILER = {
     "DEFAULT_OUTPUT_GENERATION_TYPE": "drf_viewset_profiler.output.StdOutput",
     "DEFAULT_OUTPUT_LOCATION": "",
+    "ENABLE_SERIALIZER_PROFILER": True,
 }

--- a/test-drf-project/testapp/views.py
+++ b/test-drf-project/testapp/views.py
@@ -8,12 +8,8 @@ from drf_viewset_profiler import line_profiler_viewset
 
 @line_profiler_viewset
 class TestViewSet(viewsets.ViewSet):
-    serializer_class = TestSerializer
-
     def list(self, request):
-        serializer = TestSerializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        return Response([], status=status.HTTP_200_OK)
 
     def create(self, request):
         serializer = TestSerializer(data=request.data)
@@ -21,9 +17,7 @@ class TestViewSet(viewsets.ViewSet):
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def retrieve(self, request, pk=None):
-        serializer = TestSerializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        return Response({}, status=status.HTTP_200_OK)
 
     def update(self, request, pk=None):
         serializer = TestSerializer(data=request.data)
@@ -36,9 +30,7 @@ class TestViewSet(viewsets.ViewSet):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     def destroy(self, request, pk=None):
-        serializer = TestSerializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        return Response(serializer.data, status=status.HTTP_204_NO_CONTENT)
+        return Response({}, status=status.HTTP_204_NO_CONTENT)
 
 
 @line_profiler_viewset

--- a/test-drf-project/tests/test_utils.py
+++ b/test-drf-project/tests/test_utils.py
@@ -1,31 +1,47 @@
-from drf_viewset_profiler.utils import create_line_profile
+import pytest
+
+from drf_viewset_profiler.utils import create_line_profile, get_value_from_config
+
+
+class SomeClass:
+    attr = None
+
+    def __str__(self):
+        return "SomeClass"
+
+    def _attr_0(self):
+        pass
+
+    def attr_1(self):
+        pass
+
+    @property
+    def attr_2(self):
+        pass
+
+    @staticmethod
+    def attr_3():
+        pass
+
+    @classmethod
+    def attr_4(cls):
+        pass
+
+
+class SomeAnotherClass:
+    attr = None
+
+    def __str__(self):
+        return "SomeClass"
+
+    def _attr_0(self):
+        pass
+
+    def attr_1(self):
+        pass
 
 
 def test_create_line_profile_with_class():
-    class SomeClass:
-        attr = None
-
-        def __str__(self):
-            return "SomeClass"
-
-        def _attr_0(self):
-            pass
-
-        def attr_1(self):
-            pass
-
-        @property
-        def attr_2(self):
-            pass
-
-        @staticmethod
-        def attr_3():
-            pass
-
-        @classmethod
-        def attr_4(cls):
-            pass
-
     line_profiler = create_line_profile(SomeClass)
     functions = line_profiler.functions
 
@@ -38,7 +54,41 @@ def test_create_line_profile_with_class():
     assert SomeClass.attr_4 in functions
 
 
+def test_create_line_profile_with_more_than_one_class():
+    line_profiler = create_line_profile(SomeClass, SomeAnotherClass)
+    functions = line_profiler.functions
+
+    assert SomeClass.attr not in functions
+    assert SomeClass.__str__ in functions
+    assert SomeClass._attr_0 in functions
+    assert SomeClass.attr_1 in functions
+    assert SomeClass.attr_2 not in functions
+    assert SomeClass.attr_3 in functions
+    assert SomeClass.attr_4 in functions
+
+    assert SomeAnotherClass.attr not in functions
+    assert SomeAnotherClass.__str__ in functions
+    assert SomeAnotherClass._attr_0 in functions
+    assert SomeAnotherClass.attr_1 in functions
+
+
 def test_create_line_profile_with_function():
     line_profiler = create_line_profile(lambda: True)
 
     assert len(line_profiler.functions) == 0
+
+
+def test_get_value_from_config_without_existing_config():
+    assert get_value_from_config("foo", "bar") == "bar"
+
+
+@pytest.mark.parametrize(
+    "config,expected",
+    (
+        ("DEFAULT_OUTPUT_GENERATION_TYPE", "drf_viewset_profiler.output.StdOutput"),
+        ("DEFAULT_OUTPUT_LOCATION", ""),
+        ("ENABLE_SERIALIZER_PROFILER", True),
+    ),
+)
+def test_get_value_from_config_with_existing_config(config, expected):
+    assert get_value_from_config(config, "") == expected

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py36,py37
+envlist = py36,py37,py38
 
 [testenv]
 whitelist_externals = poetry


### PR DESCRIPTION
* Improve BaseOutput to handle file location bevavior
* Add utils get_value_from_config function to retrieve drf viewset configs
* Add readme to pyprojec.toml to generate the long description in setup.py
* Add configuration `ENABLE_SERIALIZER_PROFILER`. In cases when this config is True and the viewset
has the `get_serializer_class` method, the decorator line_profiler_viewset will automatically profile
the methods and functions from the serializer vinculated with the viewset
* Add support to python 3.8
